### PR TITLE
gitswitch: bump to v0.2.0, tagged tarball, python 3.12, real test

### DIFF
--- a/Formula/gitswitch.rb
+++ b/Formula/gitswitch.rb
@@ -1,35 +1,38 @@
 class Gitswitch < Formula
   include Language::Python::Virtualenv
 
-  desc ""
-  homepage ""
-  url "https://github.com/target-ops/GitSwitch.git", branch: "main", :using => :git
-  license ""
-  version "0.1.0-alpha"
-  depends_on "python@3.9"
+  desc "Manage multiple Git identities (SSH keys, accounts, gh CLI) per vendor"
+  homepage "https://github.com/target-ops/gitswitch"
+  url "https://github.com/target-ops/gitswitch/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "a5259652efe3694c3f0661c25897ceac83b8668b7b4629a6478bcd9216f2ce5a"
+  license "MIT"
+  version "0.2.0"
+
+  depends_on "python@3.12"
 
   def install
-    # Create a virtual environment 
-    venv = virtualenv_create(libexec, "python3")
+    venv = virtualenv_create(libexec, "python3.12")
 
-    # Copy src directory and requirements.txt to libexec
     FileUtils.cp_r Dir["src"], libexec
     FileUtils.cp "requirements.txt", libexec
 
-    # Install Python dependencies
-    system libexec/"bin/python3", "-m", "pip", "install", "--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed", "--no-compile", "-r", libexec/"requirements.txt"
-    
-    # Make the script executable
+    system libexec/"bin/python3", "-m", "pip", "install",
+           "--verbose", "--no-deps", "--no-binary=:all:",
+           "--ignore-installed", "--no-compile",
+           "-r", libexec/"requirements.txt"
+
     chmod 0755, libexec/"src/main.py"
 
-    # Create a wrapper script
     (bin/"gitswitch").write <<~EOS
       #!/bin/bash
-      #{libexec}/bin/python3 #{libexec}/src/main.py "$@"
+      PYTHONPATH=#{libexec}/src #{libexec}/bin/python3 #{libexec}/src/main.py "$@"
     EOS
   end
 
   test do
-    system "false"
+    # Smoke test: the wrapper launches the venv'd Python and the click CLI loads.
+    system bin/"gitswitch", "--version"
+    assert_match "Easily manage multiple Git user profiles",
+                 shell_output("#{bin}/gitswitch --help")
   end
 end


### PR DESCRIPTION
Pairs with [target-ops/gitswitch#8](https://github.com/target-ops/gitswitch/pull/8) (merged) and the new \`v0.2.0\` tag.

## Why

Today's formula has problems that bite users:

- \`url "...gitswitch.git", branch: "main"\` — every \`brew install\` builds whatever HEAD is on main that day. Reproducibility-broken.
- \`depends_on "python@3.9"\` — Python 3.9 hit EOL October 2025; brew may yank it.
- \`version "0.1.0-alpha"\` is stale and didn't track any tag.
- Empty \`desc\`, \`homepage\`, \`license\` — \`brew info gitswitch\` shows nothing useful.
- \`test do system "false" end\` — \`brew test\` is hardcoded to fail.

## What changed

| Field | Before | After |
|---|---|---|
| \`url\` | \`...gitswitch.git\` (branch: main) | \`...archive/refs/tags/v0.2.0.tar.gz\` |
| \`sha256\` | (none — git source) | \`a5259652efe3694c3f0661c25897ceac83b8668b7b4629a6478bcd9216f2ce5a\` |
| \`version\` | \`0.1.0-alpha\` | \`0.2.0\` |
| \`depends_on\` | \`python@3.9\` (EOL) | \`python@3.12\` |
| \`desc\` | empty | \`Manage multiple Git identities (SSH keys, accounts, gh CLI) per vendor\` |
| \`homepage\` | empty | \`https://github.com/target-ops/gitswitch\` |
| \`license\` | empty | \`MIT\` |
| Wrapper | bare \`python3 main.py\` | \`PYTHONPATH=...src python3 main.py\` (resolves \`from configs.cli\`) |
| \`test\` | \`system "false"\` | \`gitswitch --version\` + \`--help\` smoke checks |

## What's in v0.2.0 itself (the source repo)

Six bug fixes that bit existing users (full list in [gitswitch#8](https://github.com/target-ops/gitswitch/pull/8)):

- \`update_ssh_config\` no longer wipes \`~/.ssh/config\` — surgically replaces just the vendor's \`Host\` block, preserves siblings.
- \`add user --username\` is honored (was silently overwritten by email local-part).
- SSH key files are namespaced per vendor (\`id_rsa_{vendor}_{username}\`) with backward-compat fallback.
- Vendor picker no longer shows \`DEFAULT\`; empty-config case prints a friendly hint.
- Network calls have a 10s timeout.
- New: \`gh auth switch --user <name>\` runs as part of \`gitswitch switch\` for github vendor.

20/20 end-to-end checks pass against an isolated tempdir HOME.

## Test plan

- [ ] \`brew untap target-ops/homebrew-tap; brew tap target-ops/homebrew-tap\` (fresh clone)
- [ ] \`brew install target-ops/tap/gitswitch\` (or \`brew upgrade gitswitch\`)
- [ ] \`gitswitch --help\` renders
- [ ] \`gitswitch generate key -v github -u test -e test@example.com\` produces \`~/.ssh/id_rsa_github_test\`
- [ ] \`gitswitch switch -v github -u test\` does not nuke unrelated entries in \`~/.ssh/config\`
- [ ] \`brew test gitswitch\` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)